### PR TITLE
Recommend the Dummy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Uses the [CTF PvP engine](https://github.com/rubenwardy/ctf_pvp_engine)
 System Requirements
 -------------------
 
-You'll need to host save your game on an SSD 
-or mount it in the ramdisk (use redis, leveldb or
-    [sqlite with this guide](https://forum.minetest.net/viewtopic.php?f=10&t=9588))
+###### Recommended
+Hosting your server using the dummy backend
+
+###### minimum
+Hosting your server using the leveldb or redis backend
+
+Hosting using sqlite on an SSD or ramdisk ([with this guide](https://forum.minetest.net/viewtopic.php?f=10&t=9588))
 
 License
 -------


### PR DESCRIPTION
Rubenwardy and I had some discussion about using the dummy backend for his server however he doesn't seem to be convince so i made this big post and maybe hopefully it at the very least get listed as an recommended backend.
____
CTF is the perfect use case for the dummy backend, the map should never get larger than 10MB and CTF doesn't need to permanently store the map, it delete the whole match area after every match, and regenerate it using the seed, something that the dummy backend do extremely well.

As long as the seed doesn't change, the world doesn't change much.
____
some basic information which was discuss with Rubenwardy:
1. how the world get generated depend on the seed, the backend doesn't affect the world
2. the game/mod state is handle by the server, the backend doesn't affect the mod
3. the files (ctf_stats.txt, ctf.txt, etc etc) are written using the lua vm, the backend doesn't affect the files

the backend only affect how the world is store and the dummy backend only store it in the ram
'delete' and 'storing' are 'handle' like other backend.

when the server tell the dummy backend to save, it store the data on the ram

when the server tell the dummy backend to delete, it delete the data on the ram.

when the server request for a specific data, if it exists: the dummy backend return the data as how it was store (like other backend),  if it doesn't exists, it tell the server that it don't have it and the server would generate it (like other backend).
____
tested using default settings unless stated otherwise

backend | time delete\* | time barrier\*\* | memory\*\*\* | map size\*\*\*
----------- | --------------- | ------------------ | ---------- | ------------
sqlite3 | too long | 0.766255 | 4.4% | 1.7MB
sqlite3 (ramdisk) | too long | 0.432125 | 4.4% | 1.7MB
sqlite3 (syncronous) | 1.148725 | 0.41057 | 4.4% | 1.7MB
sqlite3 (syncronous & ramdisk) |  1.105558 |  0.409608 | 4.4% | 1.7MB
leveldb | 0.070500999999993 | 0.440896 | 4.4% | 1.3MB
leveldb (ramdisk) | 0.088470000000001 | 0.423214 | 4.4% | 1.3MB
dummy | 0.012879999999996 | 0.418784 | 4.4% | NIL\*\*\*\*

____
notes:
* (dummy backend code: https://github.com/minetest/minetest/blob/master/src/database-dummy.cpp
* leveldb is able to handle it well enough that it doesn't really need to be place in a ramdisk.

____

\* timing the minetest.delete_area
\*\* timing the barrier delete
\*\*\* after correction message appear (see below) when starting server with the emerging the area code (see below too)
\*\*\*\* not applicable

```
[CaptureTheFlag] (flag) red has wrong node at flag position, air, correcting...
[CaptureTheFlag] (flag) blue has wrong node at flag position, default:desert_stone, correcting...
```

emerge area code:
```lua
ctf.register_on_init(function()
	local r = ctf.setting("match.map_reset_limit")
	minetest.after(0.5, function()
		minetest.emerge_area(vector.new(-r, -r, -r), vector.new(r, r, r))
	end)
end)
```