### PR TITLE
Fix looting flint from gravel

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -455,7 +455,6 @@ minetest.register_node("default:gravel", {
 	drop = {
 		max_items = 1,
 		items = {
-			{items = {'default:flint'}, rarity = 16},
 			{items = {'default:gravel'}}
 		}
 	}


### PR DESCRIPTION
Fixed #95 by removing flint from list of possible items from gravel.