### PR TITLE
Dynamic bounties, and minor changes to the rankings league table

### DIFF
--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -1,9 +1,10 @@
 local bountied_player = nil
+local bounty_score = 0
 
 local function announce(name)
 	minetest.chat_send_player(name,
 			minetest.colorize("#fff326", "The next person to kill " .. bountied_player ..
-			" will receive 150 points!"))
+			" will receive " .. bounty_score .. " points!"))
 end
 
 local function announce_all()
@@ -43,6 +44,14 @@ local function bounty_find_new_target()
 
 	if #players > 0 then
 		bounty_player(players[math.random(1, #players)].name)
+		
+		-- 				  Score * K/D
+		-- bounty_score = -----------, or 1000 (whichever is lesser)
+		--                   10000
+		bounty_score = (pstat.score * (pstat.kills / pstat.deaths)) / 10000
+		if bounty_score > 1000
+			bounty_score = 1000
+		end
 	end
 
 	minetest.after(math.random(500, 1000), bounty_find_new_target)

--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -74,8 +74,8 @@ ctf.register_on_killedplayer(function(victim, killer)
 	if victim == bountied_player then
 		local main, match = ctf_stats.player(killer)
 		if main and match then
-			main.score  = main.score  + 150
-			match.score = match.score + 150
+			main.score  = main.score  + bounty_score
+			match.score = match.score + bounty_score
 			ctf.needs_save = true
 		end
 		bountied_player = nil

--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -44,7 +44,7 @@ function ctf_stats.get_formspec(title, players)
 			"," .. pstat.captures ..
 			"," .. pstat.attempts ..
 			"," .. math.floor(pstat.score*10)/10
-		if i > 40 then
+		if i > 49 then
 			break
 		end
 	end
@@ -86,7 +86,7 @@ function ctf_stats.get_html(title, players)
 			"</td><td>" .. pstat.captures ..
 			"</td><td>" .. pstat.attempts ..
 			"</td><td>" .. math.floor(pstat.score*10)/10 .. "</td></tr>"
-		if i > 40 then
+		if i > 49 then
 			break
 		end
 	end


### PR DESCRIPTION
## Proposed changes:
- Rankings league table now displays top 50 players (used to be 41 before)
- Bounties are dynamically calculated (instead of a static 150 for all players) from the target's score and K/D (refer to the commit for the exact calculation)