### PR TITLE
Colored chat messages for various mods

### DIFF
--- a/mods/afkkick/init.lua
+++ b/mods/afkkick/init.lua
@@ -51,7 +51,7 @@ minetest.register_globalstep(function(dtime)
 
 				--Warn player if he/she has less than WARN_TIME seconds to move or be kicked
 				if players[playerName]["lastAction"] + MAX_INACTIVE_TIME - WARN_TIME < currGameTime then
-					minetest.chat_send_player(playerName, "Warning, you have " .. tostring(players[playerName]["lastAction"] + MAX_INACTIVE_TIME - currGameTime) .. " seconds to move or be kicked")
+					minetest.chat_send_player(playerName, minetest.colorize(#FF8C00,"Warning, you have " .. tostring(players[playerName]["lastAction"] + MAX_INACTIVE_TIME - currGameTime) .. " seconds to move or be kicked"))
 				end
 			end
 

--- a/mods/email/init.lua
+++ b/mods/email/init.lua
@@ -70,7 +70,7 @@ minetest.register_on_joinplayer(function(player)
 	if #inbox > 0 then
 		minetest.after(10, function()
 			minetest.chat_send_player(player:get_player_name(),
-				"(" ..  #inbox .. ") You have mail! Type /inbox to recieve")
+				minetest.colorize(#00FF00,"(" ..  #inbox .. ") You have mail! Type /inbox to recieve"))
 		end)
 	end
 end)

--- a/mods/report/init.lua
+++ b/mods/report/init.lua
@@ -64,7 +64,7 @@ minetest.register_chatcommand("report", {
 			local toname = player:get_player_name()
 			if minetest.check_player_privs(toname, {kick = true, ban = true}) then
 				table.insert(mods, toname)
-				minetest.chat_send_player(toname, "-!- " .. name .. " reported: " .. param)
+				minetest.chat_send_player(toname, minetest.colorize(#FFFF00,"-!- " .. name .. " reported: " .. param))
 			end
 		end
 

--- a/mods/respawn_immunity/init.lua
+++ b/mods/respawn_immunity/init.lua
@@ -45,7 +45,7 @@ minetest.register_on_punchplayer(function(player, hitter,
 
 	if hitter and respawn_immunity.is_immune(hitter) then
 		minetest.chat_send_player(hitter:get_player_name(),
-				"Your immunity has ended because you attacked a player")
+				minetest.colorize(#FF8C00,"Your immunity has ended because you attacked a player"))
 		immune_players[hitter:get_player_name()] = nil
 		respawn_immunity.update_effects(hitter)
 	end


### PR DESCRIPTION
## Proposed additions / changes
- Added color to many important non-chat messages, in order to highlight them better, without which they might be ignored by players who are not already actively chatting. The messages that have been colorized are:
  - New Mail notifications
  - 20-second AFK warnings
  - In-game Reports (seen only by mods)
  - "Your immunity has ended because you attacked a player"

## TODO
- Highlight messages from IRC users
- Highlight in-game PMs