### PR TITLE
Fixed issues with bounty_score

### DIFF
--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -33,6 +33,9 @@ local function bounty_player(target)
 	if bounty_score > 500 then
 		bounty_score = 500
 	end
+	if bounty_score < 50 then
+		bounty_score = 50
+	end
 
 	minetest.after(0.1, announce_all)
 end

--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -26,7 +26,7 @@ local function bounty_player(target)
 
 	--                Score * K/D
 	-- bounty_score = -----------, or 500 (whichever is lesser)
-	--                   10000
+	--                   5000
 
 	local pstat, _ = ctf_stats.player(target)
 	if pstat.deaths == 0
@@ -39,6 +39,7 @@ local function bounty_player(target)
 	if bounty_score < 50 then
 		bounty_score = 50
 	end
+	bounty_score = math.floor(bounty_score)
 
 	minetest.after(0.1, announce_all)
 end

--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -29,6 +29,9 @@ local function bounty_player(target)
 	--                   10000
 
 	local pstat, _ = ctf_stats.player(target)
+	if pstat.deaths == 0
+		pstat.deaths = 1
+	end
 	bounty_score = (pstat.score * (pstat.kills / pstat.deaths)) / 10000
 	if bounty_score > 500 then
 		bounty_score = 500

--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -29,7 +29,7 @@ local function bounty_player(target)
 	--                   5000
 
 	local pstat, _ = ctf_stats.player(target)
-	if pstat.deaths == 0
+	if pstat.deaths == 0 then
 		pstat.deaths = 1
 	end
 	bounty_score = (pstat.score * (pstat.kills / pstat.deaths)) / 10000

--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -24,7 +24,7 @@ local function bounty_player(target)
 
 	bountied_player = target
 
-	--		  Score * K/D
+	--                Score * K/D
 	-- bounty_score = -----------, or 500 (whichever is lesser)
 	--                   10000
 


### PR DESCRIPTION
## Proposed changes
- Set lower limit of 50 points.
- Added check to prevent division-by-0 error if `pstat.deaths==0`
- Rounded off the final score before announcement.
- Reduced divisor from 10000 to 5000, to prevent too small a bounty on targets.

`bounty_score = 50 < ((Score*K/D)/5000) < 500`
`bounty_score is limited to any value between 50 and 500`