### PR TITLE
Improve match summary stats

### DIFF
--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -1,14 +1,41 @@
+local function render_per_team_stats(red, blue, stat, round)
+	local red_stat, blue_stat = red[stat], blue[stat]
+	if round then
+		red_stat = math.floor(red_stat*10)/10
+		blue_stat = math.floor(blue_stat*10)/10
+	end
+	return red_stat+blue_stat .. " (" .. minetest.colorize(red.color, tostring(red_stat)) .. " - " .. minetest.colorize(blue.color, tostring(blue_stat)) .. ")"
+end
+
 function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player, time)
 	local players = {}
+	local red = {
+		color = ctf.flag_colors.red:gsub("0x", "#"),
+		kills = 0,
+		attempts = 0,
+		score = 0,
+	}
+	local blue = {
+		color = ctf.flag_colors.blue:gsub("0x", "#"),
+		kills = 0,
+		attempts = 0,
+		score = 0,
+	}
 	for name, pstat in pairs(stats.red) do
 		pstat.name = name
 		pstat.color = ctf.flag_colors.red
 		table.insert(players, pstat)
+		red.kills = red.kills + pstat.kills
+		red.attempts = red.attempts + pstat.attempts
+		red.score = red.score + pstat.score
 	end
 	for name, pstat in pairs(stats.blue) do
 		pstat.name = name
 		pstat.color = ctf.flag_colors.blue
 		table.insert(players, pstat)
+		blue.kills = blue.kills + pstat.kills
+		blue.attempts = blue.attempts + pstat.attempts
+		blue.score = blue.score + pstat.score
 	end
 
 	local ret = ctf_stats.get_formspec("Match Summary", players, 1)
@@ -22,19 +49,10 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 		ret = ret .. "label[1,0;NO WINNER]"
 	end
 
-	local total_kills = 0
-	local total_attempts = 0
-	local total_score = 0
-	for i, pstat in ipairs(players) do
-		total_kills = total_kills + pstat.kills
-		total_attempts = total_attempts + pstat.attempts
-		total_score = total_score + pstat.score
-	end
-
 	ret = ret .. "label[4,0;Kills]"
-	ret = ret .. "label[6,0;" .. total_kills .. "]"
+	ret = ret .. "label[6,0;" .. render_per_team_stats(red, blue, "kills") .. "]"
 	ret = ret .. "label[4,0.5;Attempts]"
-	ret = ret .. "label[6,0.5;" .. total_attempts .. "]"
+	ret = ret .. "label[6,0.5;" .. render_per_team_stats(red, blue, "attempts") .. "]"
 
 	local time_display = ""
 	if time >= 3600 then
@@ -44,7 +62,7 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 	ret = ret .. "label[8,0;Duration]"
 	ret = ret .. "label[10,0;" .. time_display .. "]"
 	ret = ret .. "label[8,0.5;Total score]"
-	ret = ret .. "label[10,0.5;" .. math.floor(total_score*10)/10 .. "]"
+	ret = ret .. "label[10,0.5;" .. render_per_team_stats(red, blue, "score", true) .. "]"
 
 	ret = ret .. "label[3.5,7.2;Tip: type /rankings for league tables]"
 	return ret

--- a/mods/ctf_stats/init.lua
+++ b/mods/ctf_stats/init.lua
@@ -76,6 +76,8 @@ function ctf_stats.load()
 		blue = {}
 	}
 
+	ctf_stats.start = os.time()
+
 	-- Strip players which have no score
 	for name, player_stats in pairs(ctf_stats.players) do
 		if not player_stats.score or player_stats.score <= 0 then
@@ -138,6 +140,9 @@ ctf_match.register_on_skip_map(function()
 	ctf_stats.matches.skipped = ctf_stats.matches.skipped + 1
 end)
 
+local winner_team = "-"
+local winner_player = "-"
+
 ctf_flag.register_on_capture(function(name, flag)
 	local main, match = ctf_stats.player(name)
 	if main and match then
@@ -147,15 +152,17 @@ ctf_flag.register_on_capture(function(name, flag)
 		match.score    = match.score    + 25
 		ctf.needs_save = true
 	end
+	winner_player = name
 end)
 
 ctf_match.register_on_winner(function(winner)
 	ctf.needs_save = true
 	ctf_stats.matches.wins[winner] = ctf_stats.matches.wins[winner] + 1
+	winner_team = winner
 end)
 
 ctf_match.register_on_new_match(function()
-	local fs = ctf_stats.get_formspec_match_summary(ctf_stats.current)
+	local fs = ctf_stats.get_formspec_match_summary(ctf_stats.current, winner_team, winner_player, os.time()-ctf_stats.start)
 	local players = minetest.get_connected_players()
 	for _, player in pairs(players) do
 		minetest.show_formspec(player:get_player_name(), "ctf_stats:eom", fs)
@@ -165,6 +172,9 @@ ctf_match.register_on_new_match(function()
 		red = {},
 		blue = {}
 	}
+	winner_team = "-"
+	winner_player = "-"
+	ctf_stats.start = os.time()
 	ctf.needs_save = true
 end)
 


### PR DESCRIPTION
I'm trying to improve the formspec displaying the match summary. I've added a flag image with the color of the winner team, and some information (total kills, score, duration…) at the top of the window.
![screenshot_20180417_091906](https://user-images.githubusercontent.com/6905002/38854436-c299ca78-4220-11e8-8549-73b3610fa002.png)

This may need more testing before being merged, in particular I'd like to see how it behaves on small screens. Also, feel free to give your opinion about window layout or code quality.