### PR TITLE
Fixed error that bugged team-door crafting

### DIFF
--- a/mods/ctf_crafting/init.lua
+++ b/mods/ctf_crafting/init.lua
@@ -83,7 +83,7 @@ crafting.register_recipe({
 crafting.register_recipe({
 	type   = "inv",
 	output = "doors:door_steel",
-	items  = { "default:steel 6" },
+	items  = { "default:steel_ingot 6" },
 	always_known = true,
 	level  = 1,
 })


### PR DESCRIPTION
Changed `default:steel` to `default:steel_ingot` here:

```
crafting.register_recipe({
 	type   = "inv",
 	output = "doors:door_steel",
	items  = { "default:steel_ingot 6" },   <----------
 	always_known = true,
 	level  = 1,
 })
```