### PR TITLE
Replace team allocation algorithm with one that takes more statistics into account

### DIFF
--- a/mods/ctf_alloc/init.lua
+++ b/mods/ctf_alloc/init.lua
@@ -44,8 +44,12 @@ function ctf_alloc.set_all()
 		return {
 			player = a,
 			score = stats.score,
+			
 			kills = stats.kills,
-			deaths = stats.deaths
+			deaths = stats.deaths,
+			
+			captures = stats.captures,
+			attempts = stats.attempts
 		}
 	end)
 	table.sort(players, function(a, b)
@@ -54,7 +58,7 @@ function ctf_alloc.set_all()
 
 	minetest.log("warning", dump(players))
 	
-	local kd_diff = 0
+	local index_diff = 0
 	
 	for _, spair in pairs(players) do
 		local player     = spair.player
@@ -63,17 +67,19 @@ function ctf_alloc.set_all()
 		local team
 		local to_red
 		
-		if kd_diff == 0 then
+		if index_diff == 0 then
 			to_red = math.random(1, 2) == 1
 		else
-			to_red = kd_diff < 0
+			to_red = index_diff < 0
 		end
 		
+		local index = spair.kills / (spair.deaths + 1) + spair.captures * 5 / (spair.attempts - spair.captures + 1)
+		
 		if to_red then
-			kd_diff = kd_diff + spair.kills / (spair.deaths + 1)
+			index_diff = index_diff + index
 			team = "red"
 		else
-			kd_diff = kd_diff - spair.kills / (spair.deaths + 1)
+			index_diff = index_diff - index
 			team = "blue"
 		end
 

--- a/mods/ctf_alloc/init.lua
+++ b/mods/ctf_alloc/init.lua
@@ -44,6 +44,8 @@ function ctf_alloc.set_all()
 		return {
 			player = a,
 			score = stats.score,
+			kills = stats.kills,
+			deaths = stats.deaths
 		}
 	end)
 	table.sort(players, function(a, b)
@@ -51,19 +53,29 @@ function ctf_alloc.set_all()
 	end)
 
 	minetest.log("warning", dump(players))
-
-	local to_red = math.random(2) == 2
+	
+	local kd_diff = 0
+	
 	for _, spair in pairs(players) do
 		local player     = spair.player
 		local name       = player:get_player_name()
 		local alloc_mode = tonumber(ctf.setting("allocate_mode"))
 		local team
+		local to_red
+		
+		if kd_diff == 0 then
+			to_red = math.random(1, 2) == 1
+		else
+			to_red = kd_diff < 0
+		end
+		
 		if to_red then
+			kd_diff = kd_diff + spair.kills / (spair.deaths + 1)
 			team = "red"
 		else
+			kd_diff = kd_diff - spair.kills / (spair.deaths + 1)
 			team = "blue"
 		end
-		to_red = not to_red
 
 		if alloc_mode ~= 0 and team then
 			ctf.log("autoalloc", name .. " was allocated to " .. team)


### PR DESCRIPTION
Mostly untested because I cannot figure out how to get either version to run properly in a singleplayer world without errors.

The algorithm sorts the table in descending order of score to begin with, similarly to the current algorithm (might change that). For the first player and any time in which the total K/D ratio of both teams happen to be equal, a random team is selected. Otherwise, the player is added to the team with the lowest K/D ratio.

It doesn't keep track of the total K/D ratio of both teams; rather it keeps a single "K/D difference" variable which increases for red K/D and decreases for blue K/D.

The algorithm now treats every successful capture as equivalent to 5 kills, meaning that it is now more complex than the above explanation but the code is hopefully simple to understand.