### PR TITLE
Deprecate /rankings me

### DIFF
--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -258,7 +258,7 @@ minetest.register_chatcommand("rankings", {
 				return false, "Can't find player '" .. param .. "'"
 			end
 		else
-			target = name			
+			target = name
 		end
 
 		if not minetest.get_player_by_name(name) then
@@ -266,7 +266,7 @@ minetest.register_chatcommand("rankings", {
 		else
 			local players = {}
 			for pname, pstat in pairs(ctf_stats.players) do
-				pstat.name  = pname
+				pstat.name = pname
 				pstat.color = nil
 				table.insert(players, pstat)
 			end

--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -68,14 +68,14 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 	return ret
 end
 
-function ctf_stats.get_formspec(title, players, header)
+function ctf_stats.get_formspec(title, players, header, highlight)
 	table.sort(players, function(one, two)
 		return one.score > two.score
 	end)
 
-	local ret = "size[12,"..6.5+header.."]"
+	local ret = "size[12," .. 6.5 + header .. "]"
 	ret = ret .. default.gui_bg .. default.gui_bg_img
-	ret = ret .. "container[0,"..header.."]"
+	ret = ret .. "container[0," .. header .. "]"
 
 	ret = ret .. "vertlabel[0,0;" .. title .. "]"
 	ret = ret .. "tablecolumns[color;text;text;text;text;text;text;text;text;text]"
@@ -85,7 +85,12 @@ function ctf_stats.get_formspec(title, players, header)
 
 	for i = 1, #players do
 		local pstat = players[i]
-		local color = pstat.color or "#ffffff"
+		local color
+		if pstat.name == highlight then
+			color = "#ffff00"
+		else
+			color = pstat.color or "#ffffff"
+		end
 		local kd = pstat.kills
 		if pstat.deaths > 0 then
 			kd = kd / pstat.deaths
@@ -96,11 +101,11 @@ function ctf_stats.get_formspec(title, players, header)
 			"," .. pstat.name ..
 			"," .. pstat.kills ..
 			"," .. pstat.deaths ..
-			"," .. math.floor(kd*10)/10  ..
+			"," .. math.floor(kd * 10) / 10  ..
 			"," .. pstat.bounty_kills ..
 			"," .. pstat.captures ..
 			"," .. pstat.attempts ..
-			"," .. math.floor(pstat.score*10)/10
+			"," .. math.floor(pstat.score * 10) / 10
 		if i > 49 then
 			break
 		end
@@ -216,9 +221,7 @@ end
 
 minetest.register_chatcommand("rankings", {
 	func = function(name, param)
-		if param == "me" then
-			return send_as_chat_result(name, name)
-		elseif param ~= "" then
+		if param ~= "" then
 			if ctf_stats.players[param:trim()] then
 				return send_as_chat_result(name, param:trim())
 			else
@@ -231,8 +234,7 @@ minetest.register_chatcommand("rankings", {
 				pstat.color = nil
 				table.insert(players, pstat)
 			end
-			local fs = ctf_stats.get_formspec("Player Rankings", players, 0)
-			fs = fs .. "label[3.5,6.2;Tip: to see where you are, type /rankings me]"
+			local fs = ctf_stats.get_formspec("Player Rankings", players, 0, name)
 			minetest.show_formspec(name, "ctf_stats:rankings", fs)
 		end
 	end

--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -153,13 +153,14 @@ function ctf_stats.get_html(title, players)
 	local ret = "<h1>" .. title .. "</h1>"
 	ret = ret .. "<table>" ..
 		"<tr><th></th>" ..
-		"<th>username</th>" ..
-		"<th>kills</th>" ..
-		"<th>deaths</th>" ..
+		"<th>Player</th>" ..
+		"<th>Kills</th>" ..
+		"<th>Deaths</th>" ..
 		"<th>K/D ratio</th>" ..
-		"<th>captures</th>" ..
-		"<th>attempts</th>" ..
-		"<th>score</th></tr>"
+		"<th>Bounty kills</th>" ..
+		"<th>Captures</th>" ..
+		"<th>Attempts</th>" ..
+		"<th>Score</th></tr>"
 
 	for i = 1, math.min(#players, 50) do
 		local pstat = players[i]
@@ -172,7 +173,8 @@ function ctf_stats.get_html(title, players)
 			"</td><td>" .. pstat.name ..
 			"</td><td>" .. pstat.kills ..
 			"</td><td>" .. pstat.deaths ..
-			"</td><td>" .. math.floor(kd*10)/10 ..
+			"</td><td>" .. math.floor(kd * 10) / 10 ..
+			"</td><td>" .. pstat.bounty_kills ..
 			"</td><td>" .. pstat.captures ..
 			"</td><td>" .. pstat.attempts ..
 			"</td><td>" .. math.floor(pstat.score*10)/10 .. "</td></tr>"
@@ -227,7 +229,7 @@ local function send_as_chat_result(to, name)
 	if place < 1 then
 		place = #players + 1
 	end
-	local you_are_in = (to == name) and "You are in " or "They are in "
+	local you_are_in = (to == name) and "You are in " or name ..  " is in "
 	local result = you_are_in .. place .. " place."
 	if me then
 		local kd = me.kills
@@ -236,7 +238,8 @@ local function send_as_chat_result(to, name)
 		end
 		result = result .. "Kills: " .. me.kills ..
 			" | Deaths: " .. me.deaths ..
-			" | K/D: " .. math.floor(kd*10)/10 ..
+			" | K/D: " .. math.floor(kd * 10) / 10 ..
+			" | Bounty kills: " .. me.bounty_kills ..
 			" | Captures: " .. me.captures ..
 			" | Attempts: " .. me.attempts ..
 			" | Score: " .. math.floor(me.score)
@@ -248,11 +251,11 @@ minetest.register_chatcommand("rankings", {
 	func = function(name, param)
 		local target
 		if param ~= "" then
-			local param_name = param:trim()
-			if ctf_stats.players[param_name] then
-				target = param_name
+			param = param:trim()
+			if ctf_stats.players[param] then
+				target = param
 			else
-				return false, "Can't find player '" .. param:trim() .. "'"
+				return false, "Can't find player '" .. param .. "'"
 			end
 		else
 			target = name			

--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -85,7 +85,7 @@ function ctf_stats.get_formspec(title, players, header, hlt_name)
 
 	local player_in_top_50 = false
 
-	for i = 1, math.min(#players, 3) do
+	for i = 1, math.min(#players, 50) do
 		local pstat = players[i]
 		local color
 		if hlt_name and pstat.name == hlt_name then

--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -122,32 +122,26 @@ function ctf_stats.get_formspec(title, players, header, hlt_name)
 			end
 		end
 
-		print("Appending hlt_player's stats to players{}")
 		hlt_kd = hlt_player.kills
 		if hlt_player.deaths > 1 then
 			hlt_kd = hlt_kd / hlt_player.deaths
 		end
-		local append =
-			"," .. "#ffff00" ..
-			"," .. hlt_rank ..
-			"," .. hlt_player.name ..
-			"," .. hlt_player.kills ..
-			"," .. hlt_player.deaths ..
-			"," .. math.floor(hlt_kd * 10) / 10  ..
-			"," .. hlt_player.bounty_kills ..
-			"," .. hlt_player.captures ..
-			"," .. hlt_player.attempts ..
-			"," .. math.floor(hlt_player.score * 10) / 10
-		ret = ret .. append
-		print("Appended!")
+		ret = ret ..
+			  "," .. "#ffff00" ..
+			  "," .. hlt_rank ..
+			  "," .. hlt_player.name ..
+			  "," .. hlt_player.kills ..
+			  "," .. hlt_player.deaths ..
+			  "," .. math.floor(hlt_kd * 10) / 10  ..
+			  "," .. hlt_player.bounty_kills ..
+			  "," .. hlt_player.captures ..
+			  "," .. hlt_player.attempts ..
+			  "," .. math.floor(hlt_player.score * 10) / 10
 	end
 
 	ret = ret .. ";-1]"
 	ret = ret .. "button_exit[0.5,6;3,1;close;Close]"
 	ret = ret .. "container_end[]"
-
-	print("Final formspec string:\n"..ret)
-
 	return ret
 end
 
@@ -208,48 +202,6 @@ function ctf_stats.html_to_file(filepath)
 	f:close()
 end
 
-local function send_as_chat_result(to, name)
-	local players = {}
-	for pname, pstat in pairs(ctf_stats.players) do
-		pstat.name = pname
-		pstat.color = nil
-		table.insert(players, pstat)
-	end
-
-	table.sort(players, function(one, two)
-		return one.score > two.score
-	end)
-
-	local place = -1
-	local me = nil
-	for i = 1, #players do
-		local pstat = players[i]
-		if pstat.name == name then
-			me = pstat
-			place = i
-			break
-		end
-	end
-	if place < 1 then
-		place = #players + 1
-	end
-	local you_are_in = (to == name) and "You are in " or "They are in "
-	local result = you_are_in .. place .. " place.\n"
-	if me then
-		local kd = me.kills
-		if me.deaths > 1 then
-			kd = kd / me.deaths
-		end
-		result = result .. "Kills: " .. me.kills ..
-			" | Deaths: " .. me.deaths ..
-			" | K/D: " .. math.floor(kd*10)/10 ..
-			" | Captures: " .. me.captures ..
-			" | Attempts: " .. me.attempts ..
-			" | Score: " .. math.floor(me.score)
-	end
-	return true, result
-end
-
 minetest.register_chatcommand("rankings", {
 	func = function(name, param)
 		local target
@@ -261,7 +213,7 @@ minetest.register_chatcommand("rankings", {
 				return false, "Can't find player '" .. param:trim() .. "'"
 			end
 		else
-			target = name			
+			target = name
 		end
 
 		local players = {}

--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -266,7 +266,7 @@ minetest.register_chatcommand("rankings", {
 		else
 			local players = {}
 			for pname, pstat in pairs(ctf_stats.players) do
-				pstat.name = pname
+				pstat.name  = pname
 				pstat.color = nil
 				table.insert(players, pstat)
 			end

--- a/mods/random_messages/init.lua
+++ b/mods/random_messages/init.lua
@@ -60,12 +60,12 @@ function random_messages.read_messages()
 		"Like CTF? Give feedback using /report, and consider donating at rubenwardy.com/donate",
 		"Map makers needed! Visit ctf.rubenwardy.com to get involved.",
 		"Using limited resources for building structures that don't strengthen your base's defences is discouraged.",
-		"To report misbehaving players to moderators, please use /report NAME MESSAGE",
+		"To report misbehaving players to moderators, please use /report <name> <action>",
 		"Swearing, trolling and being rude will not be tolerated and strict action will be taken.",
-		"Trapping team mates on purpose is strictly against the rules and you will be kicked / banned immediately.",
+		"Trapping team mates on purpose is strictly against the rules and you will be kicked immediately.",
 		"Help your team claim victory by storing extra weapons in the team chest, and never taking more than you need.",
-		"Note: The maximum number of apples in a stack has been reduced from 99 to 30.",
-		"Excessive spawn-killing is a direct violation of the rules - appropriate punishments will be given."
+		"Excessive spawn-killing is a direct violation of the rules - appropriate punishments will be given.",
+		"Check your score and your rank in the league tables using /rankings"
 	}
 end
 


### PR DESCRIPTION
## Proposed changes
- Deprecate `/rankings me`, `/rankings` is used to check own stats too.
- On `/rankings`, the league table is displayed with caller's stats highlighted in yellow.
  - If in top 50, stats are highlighted as-is.
  - If not in top 50, stats are appended to the bottom of the list.

Extensively tested. Ready to merge.
****
*Note:* The number of players displayed on the rankings table by default, had been reduced to 3 (as seen in the screenshot) for testing purposes only.

Player in top 50:
![Player in top 50](https://user-images.githubusercontent.com/36130650/42073984-5865cf94-7b87-11e8-9438-928f75cddace.png)

Player not in top 50:
![Player _not_ in top 50](https://user-images.githubusercontent.com/36130650/42073985-58a1f708-7b87-11e8-932f-9c03f43b32ea.png)

Closes #81 