### PR TITLE
Fix bounty color

### DIFF
--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -2,7 +2,7 @@ local bountied_player = nil
 local bounty_score = 0
 
 local function announce(name)
-	local _, tcolor = ctf_colors.get_color(name, ctf.player(name))
+	local _, tcolor = ctf_colors.get_color(bountied_player, ctf.player(bountied_player))
 	tcolor = tcolor:gsub("0x", "#")
 	minetest.chat_send_player(name,
 			minetest.colorize("#fff326", "The next person to kill ") ..


### PR DESCRIPTION
The color for the bounty holder was wrong, it was set to the color of the player who receives the message instead of the target player.

Not tested yet.