### PR TITLE
Prevent chests from spawning on trees

### DIFF
--- a/mods/tsm_chests/init.lua
+++ b/mods/tsm_chests/init.lua
@@ -18,6 +18,7 @@
 local disallowed_base_nodes = {
 	"default:leaves",
 	"default:jungleleaves",
+	"default:pine_needles",
 	"default:acacia_leaves",
 	"default:aspen_leaves",
 	"default:tree",

--- a/mods/tsm_chests/init.lua
+++ b/mods/tsm_chests/init.lua
@@ -15,6 +15,17 @@
 	For this, there is another example mod, called “trm_default_example”, which registers a bunch of items of the default mod, like default:gold_ingot.
 ]]
 
+local disallowed_base_nodes = {
+	"default:leaves",
+	"default:jungleleaves",
+	"default:acacia_leaves",
+	"default:aspen_leaves",
+	"default:tree",
+	"default:jungletree",
+	"default:pine_tree",
+	"default:acacia_tree",
+	"default:aspen_tree"
+}
 
 local chest_formspec =
 	"size[8,9]" ..
@@ -197,6 +208,19 @@ function place_chests(minp, maxp, seed, number_chests)
 		local ground = findGroundLevel(pos, y_min, y_max)
 		if ground ~= nil then
 			local chest_pos = {x = pos.x, y = ground + 1, z = pos.z}
+			local ground_pos = {x = pos.x, y = ground, z = pos.z}
+
+			-- Don't spawn on trees
+			local disallowed_base = false
+			local chest_base = minetest.get_node(ground_pos).name
+			for _, disallowed_base_node in ipairs(disallowed_base_nodes) do
+				if chest_base == disallowed_base_node then
+					disallowed_base = true
+				end
+			end
+			if disallowed_base then
+				break
+			end
 
 			-- Don't spawn at barrier
 			if chest_pos.z == 0 then


### PR DESCRIPTION
Closes #90 

## Proposed changes
- Add a local table of blacklisted node-names. (Currently includes all `default:*leaves` `default:pine_needles` and `default:*tree`)
- Skip placing chest if name of node underneath matches a blacklist entry.