### PR TITLE
Prevent abuse of bounty by committing suicide

### DIFF
--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -80,6 +80,10 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 ctf.register_on_killedplayer(function(victim, killer)
+	-- Suicide is not encouraged here at CTF
+	if victim == killer
+		return
+	end
 	if victim == bountied_player then
 		local main, match = ctf_stats.player(killer)
 		if main and match then

--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -81,7 +81,7 @@ end)
 
 ctf.register_on_killedplayer(function(victim, killer)
 	-- Suicide is not encouraged here at CTF
-	if victim == killer
+	if victim == killer then
 		return
 	end
 	if victim == bountied_player then


### PR DESCRIPTION
## Proposed Changes
- Prevent player from being able to bag their own bounty by committing suicide with a grenade (Closes #162)