### PR TITLE
Fix ladder recipe; add ladder->stick recipe

### DIFF
--- a/mods/ctf_crafting/init.lua
+++ b/mods/ctf_crafting/init.lua
@@ -107,7 +107,7 @@ crafting.register_recipe({
 crafting.register_recipe({
 	type   = "inv",
 	output = "default:torch 5",
-	items  = { "default:stick", "default:coal_lump"},
+	items  = { "default:stick", "default:coal_lump" },
 	always_known = true,
 	level  = 1,
 })
@@ -115,7 +115,15 @@ crafting.register_recipe({
 crafting.register_recipe({
 	type   = "inv",
 	output = "default:ladder 5",
-	items  = { "group:wood 7"},
+	items  = { "default:stick 7" },
+	always_known = true,
+	level  = 1,
+})
+
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:stick 2",
+	items  = { "default:ladder" },
 	always_known = true,
 	level  = 1,
 })

--- a/mods/ctf_crafting/init.lua
+++ b/mods/ctf_crafting/init.lua
@@ -127,3 +127,35 @@ crafting.register_recipe({
 	always_known = true,
 	level  = 1,
 })
+
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:wood 3",
+	items  = { "default:pick_wood" },
+	always_known = true,
+	level  = 1,
+})
+
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:wood 2",
+	items  = { "default:sword_wood" },
+	always_known = true,
+	level  = 1,
+})
+
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:wood 3",
+	items  = { "default:axe_wood" },
+	always_known = true,
+	level  = 1,
+})
+
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:wood 1",
+	items  = { "default:shovel_wood" },
+	always_known = true,
+	level  = 1,
+})


### PR DESCRIPTION
### Proposed changes
- Ladder's craft recipe requires `default:stick 7` and not `default:wood 7`; fixed.
- Add recipe for obtaining 2 sticks from a ladder. i.e. Make ladder crafting reversible.

@rubenwardy, I'll also add recipes for `wooden tools -> sticks and wood` if that's ok with you...