### PR TITLE
[WIP] Implement item blacklisting for team chests

### DIFF
--- a/mods/ctf_team_base/chest.lua
+++ b/mods/ctf_team_base/chest.lua
@@ -1,3 +1,6 @@
+local blacklist = {
+}
+
 local function max(a, b)
 	return (a > b) and a or b
 end
@@ -110,6 +113,12 @@ for _, chest_color in pairs(colors) do
 			if chest_color ~= ctf.player(player:get_player_name()).team then
 				minetest.chat_send_player(player:get_player_name(), "You're not on team " .. chest_color)
 				return 0
+			end
+
+			for itemstring in ipairs(blacklist) do
+				if stack:get_name() == itemstring then
+					return 0
+				end
 			end
 
 			local pstat = ctf_stats.player(player:get_player_name())


### PR DESCRIPTION
- Restrict unnecessary junk from being added to the team-chest.

The blacklisting code is in place, but the actual items to be blacklisted needs to be decided upon. Items that were useless some time ago now have some added value. Think `default:wood_<tool>`->`default:wood`. Even leaves can be used to quickly climb heights by making 1x1 towers without using cobble... I find saplings useless, but in that case, they should be completely removed from the game. Is this even required? Nevertheless, closes #63 :P