### PR TITLE
Remove gold-related nodes and craftitems

### DIFF
--- a/mods/ctf_map/schem_map.lua
+++ b/mods/ctf_map/schem_map.lua
@@ -21,6 +21,7 @@ minetest.register_alias("default:sand_with_kelp", "default:sand")
 minetest.register_alias("default:grass_5", "air")
 minetest.register_alias("default:bush_leaves", "air")
 minetest.register_alias("default:bush_stem", "air")
+minetest.register_alias("default:stone_with_gold", "default:stone")
 
 
 local max_r  = 120

--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -625,12 +625,6 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "cooking",
-	output = "default:gold_ingot",
-	recipe = "default:gold_lump",
-})
-
-minetest.register_craft({
-	type = "cooking",
 	output = "default:clay_brick",
 	recipe = "default:clay_lump",
 })

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -32,11 +32,6 @@ minetest.register_craftitem("default:mese_crystal", {
 	inventory_image = "default_mese_crystal.png",
 })
 
-minetest.register_craftitem("default:gold_lump", {
-	description = "Gold Lump",
-	inventory_image = "default_gold_lump.png",
-})
-
 minetest.register_craftitem("default:diamond", {
 	description = "Diamond",
 	inventory_image = "default_diamond.png",
@@ -65,11 +60,6 @@ minetest.register_craftitem("default:tin_ingot", {
 minetest.register_craftitem("default:bronze_ingot", {
 	description = "Bronze Ingot",
 	inventory_image = "default_bronze_ingot.png",
-})
-
-minetest.register_craftitem("default:gold_ingot", {
-	description = "Gold Ingot",
-	inventory_image = "default_gold_ingot.png"
 })
 
 minetest.register_craftitem("default:mese_crystal_fragment", {

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -805,15 +805,6 @@ minetest.register_node("default:mese", {
 	light_source = 3,
 })
 
-
-minetest.register_node("default:stone_with_gold", {
-	description = "Gold Ore",
-	tiles = {"default_stone.png^default_mineral_gold.png"},
-	groups = {cracky = 2},
-	drop = "default:gold_lump",
-	sounds = default.node_sound_stone_defaults(),
-})
-
 minetest.register_node("default:stone_with_diamond", {
 	description = "Diamond Ore",
 	tiles = {"default_stone.png^default_mineral_diamond.png"},


### PR DESCRIPTION
Removed items:
- `default:stone_with_gold`
- `default:gold_ingot`
- `default:gold_lump`

Alias registered to convert gold ore to plain stone.