### PR TITLE
Write to map.conf after setting team.*.*

### DIFF
--- a/mods/ctf_map/map_maker.lua
+++ b/mods/ctf_map/map_maker.lua
@@ -281,7 +281,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		meta:set("rotation", center_barrier_rot == 0 and "x" or "z")
 		meta:set("r", center.r)
 		meta:set("h", center.h)
-		meta:write()
 
 		for _, flags in pairs(flag_positions) do
 			local pos = vector.subtract(flags, center)
@@ -296,6 +295,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			meta:set("team." .. idx .. ".color", pos.z > 0 and "red" or "blue")
 			meta:set("team." .. idx .. ".pos", minetest.pos_to_string(pos))
 		end
+		meta:write()
 
 		minetest.after(0.1, function()
 			local filepath = path .. mapname .. ".mts"


### PR DESCRIPTION
Previously, the meta was written to `map.conf` *before* setting the aforementioned values, which is probably why most submitted maps did not have any flags as was discovered while testing.

The `team.*.*` values had to be added by manually editing the `map.conf` file, which is a disaster, as the flag positions are taken from the centre of the map and aren't world coords.

One-line change. **Tested; works as it should**