### PR TITLE
Enable PvP during server startup

### DIFF
--- a/mods/ctf_match/init.lua
+++ b/mods/ctf_match/init.lua
@@ -12,6 +12,7 @@ dofile(minetest.get_modpath("ctf_match") .. "/vote.lua")
 
 ctf.register_on_init(function()
 	ctf._set("match.remove_player_on_leave",     false)
+	minetest.settings:set_bool("enable_pvp", true)
 end)
 
 ctf_match.register_on_build_time_end(function()


### PR DESCRIPTION
Supposed to fix issue #219
While it seems logical that with "enable_pvp" setting you can't hurt anyone, it doesn't make sense in CTF game at all.
I wanted to update #220, but github decided to close it.

In this PR I programmatically enable PvP during server startup.